### PR TITLE
Update README.md to use the correct spelling of mezzanine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Romantic
 ========
 
-Web-site of sport-club "Romantic" on mezzazine framework.
+Web-site of sport-club "Romantic" on mezzanine framework.


### PR DESCRIPTION
The repo description also spells it wrong, but you must change that manually in the repo settings. I found this repo only because I misspelled it too.